### PR TITLE
(SIMP-10572) Pulp Missing Packages

### DIFF
--- a/build/6.6.0/CentOS/8/x86_64/repo_packages.yaml
+++ b/build/6.6.0/CentOS/8/x86_64/repo_packages.yaml
@@ -226,7 +226,7 @@ AppStream:
     - stream: mysql:8.0
       # rpms:
       #   - mysql-server
-    - stream: perl:5.26
+    - stream: perl:5.30
     - stream: perl-IO-Socket-SSL:2.066
     - stream: perl-libwww-perl:6.34
       # rpms:
@@ -278,6 +278,14 @@ AppStream:
   - name: rpm-ostree
   - name: rpm-ostree-libs
   - name: rpm-plugin-fapolicyd
+  - name: rsyslog
+  - name: rsyslog-crypto
+  - name: rsyslog-doc
+  - name: rsyslog-gnutls
+  - name: rsyslog-gssapi
+  - name: rsyslog-mysql
+  - name: rsyslog-pgsql
+  - name: rsyslog-snmp
   - name: scap-security-guide
   - name: sysstat
   - name: sysfsutils


### PR DESCRIPTION
- update perl stream to 5.30.  For some reason the 5.26 stream
  does not include the perl rpm.  I updated the stream to the
  newer version.
- included rsyslog files.  rsyslog-gnutls is needed by  SIMP.