### PR TITLE
(SIMP-10584) Revert PERL version change

### DIFF
--- a/build/6.6.0/CentOS/8/x86_64/repo_packages.yaml
+++ b/build/6.6.0/CentOS/8/x86_64/repo_packages.yaml
@@ -241,7 +241,7 @@ AppStream:
     - stream: mysql:8.0
       # rpms:
       #   - mysql-server
-    - stream: perl:5.30
+    - stream: perl:5.26
     - stream: perl-IO-Socket-SSL:2.066
     - stream: perl-libwww-perl:6.34
       # rpms:

--- a/plans/in_one_container/destroy.pp
+++ b/plans/in_one_container/destroy.pp
@@ -14,7 +14,7 @@ plan pulp3::in_one_container::destroy (
   String[1]                     $container_image = lookup('pulp3::in_one_container::container_image')|$k|{'pulp/pulp'},
   Optional[Enum[podman,docker]] $runtime         = undef,
   Boolean                       $force           = lookup('pulp3::in_one_container::destroy::force')|$k|{ false },
-  Boolean                       $volumes         = lookup('pulp3::in_one_container::destroy::volumes')|$k|{ false },
+  Boolean                       $volumes         = lookup('pulp3::in_one_container::destroy::volumes')|$k|{ true },
 ) {
   $host = run_plan('pulp3::in_one_container::get_host',$targets)
   $runtime_exe = $host.facts['pioc_runtime_exe']


### PR DESCRIPTION
Changing the PERL version has a snowball effect. Reverting to the
version that worked previously.

Also changed 'destroy' to remove volumes by default.