### PR TITLE
(SIMP-10622) Mirror repos with sync_policy

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,24 @@
+{
+  "name": "simp-pulp3",
+  "version": "0.1.0",
+  "author": "SIMP Team",
+  "summary": "RELENG plans to manage Pulp3-in-one-container",
+  "license": "Apache-2.0",
+  "source": "https://github.com/simp/bolt-pulp3",
+  "project_page": "https://github.com/simp/bolt-pulp3",
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "pulp"
+  ],
+  "dependencies": [
+  ],
+  "operatingsystem_support": [
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 6.22.1 < 8.0.0"
+    }
+  ]
+}


### PR DESCRIPTION
Before this patch, Pulp would fail to mirror EPEL8 with the message:

    This repository uses features which are incompatible with 'mirror'
    sync. Please sync without mirroring enabled.

This is due to a new version of the [pulp_rpm][0] plugin that
deprecates `mirror=True`, which now refuses to mirror certain kinds repo
metadata.

This patch fixes the EPEL8 mirror by replacing the deprecated `mirror`
with the new `sync_policy`

It also adds minor sanitization tweaks for inferred dist base paths.

[SIMP-10622] #close

[SIMP-10622]: https://simp-project.atlassian.net/browse/SIMP-10622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[0]: https://docs.pulpproject.org/pulp_rpm/