### PR TITLE
Fix broken version logic, ensure modulemd_defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Fix broken version constraint logic, tolerate operator-less versions
+- Add support for modulemd_defaults
+- Update to Pulp 3:19
+  - Set `retain_repo_versions` and `retain_package_versions` for speed
+- Make env path safe for Bolt's built-in bundler
+
 - Container volume support
 - New plan `pulp3::in_one_container::get_logs`, to fetch and review django logs
   from inside the running Pulp container

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'pulp_rpm_client'
 gem 'bindata'
 gem 'down'
 gem 'logging'
+gem 'pry'
 
 group :development do
   gem 'puppet-lint'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,7 +3,7 @@ pulp3::server_url: http://localhost
 pulp3::server_port: 8080
 
 pulp3::in_one_container::container_name: pulp
-pulp3::in_one_container::container_image: docker.io/pulp/pulp:3.15
+pulp3::in_one_container::container_image: docker.io/pulp/pulp:3.19
 pulp3::in_one_container::container_port: "%{alias('pulp3::server_port')}"
 
 pulp3::in_one_container::django_log: '/var/run/django-info.log'


### PR DESCRIPTION
- Fix broken version constraint logic, tolerate operator-less versions
- _Explicitly_ include modulemd_defaults matching desired modulemds
- Update default to Pulp 3:19
  - Set `retain_repo_versions` and `retain_package_versions` for speed
- Make env path safe for Bolt's built-in `bundler` (optional)

Fixes #28 