### PR TITLE
Add suffix to .repo names to avoid collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Add the suffix `--simp` to the titles of all repos in
-  `simp-and-all-deps.repos` (avoids collisions with disabled repos)
-
-- Fix broken version constraint logic, tolerate operator-less versions
-- Add support for modulemd_defaults
+- Add support for `modulemd_defaults`
 - Update to Pulp 3:19
   - Set `retain_repo_versions` and `retain_package_versions` for speed
+- Fix broken version constraint logic, tolerate operator-less versions
 - Make env path safe for Bolt's built-in `bundler`
+- New optional global `_options` key for bolt_pulp3_config file
+  - New option: `default_destination_repo_baseurl`
+- Add the suffix `--simp` to the titles of all repos in
+  `simp-and-all-deps.repos` (avoids collisions with disabled repos)
 
 - Container volume support
 - New plan `pulp3::in_one_container::get_logs`, to fetch and review django logs
@@ -29,13 +30,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Internal code simplifications
 
 ### Removed
+
 - (Incomplete) never-used plans `::rpm::mirror` and `::rpm::repo`
 
 ### Fixed
 
 - Filter for podman matching
 - Container destruction
-- Bumped the pulp image to 3.15 to fix EPEL issues
+- Bumped the pulp image to fix EPEL issues
+- Mirrored Module streams did not have default profiles or groups
 
 ## [0.3.0] - 2021-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add the suffix `--simp` to the titles of all repos in
+  `simp-and-all-deps.repos` (avoids collisions with disabled repos)
+
 - Fix broken version constraint logic, tolerate operator-less versions
 - Add support for modulemd_defaults
 - Update to Pulp 3:19
   - Set `retain_repo_versions` and `retain_package_versions` for speed
-- Make env path safe for Bolt's built-in bundler
+- Make env path safe for Bolt's built-in `bundler`
 
 - Container volume support
 - New plan `pulp3::in_one_container::get_logs`, to fetch and review django logs

--- a/README.md
+++ b/README.md
@@ -2,23 +2,24 @@
 
 <!-- vim-markdown-toc GFM -->
 
-* [Overview](#overview)
-  * [Setup](#setup)
-    * [Setup Requirements](#setup-requirements)
-      * [OS requirements](#os-requirements)
-      * [OS Storage requirements](#os-storage-requirements)
-      * [Runtime dependencies](#runtime-dependencies)
-      * [Avoiding conflicts with RubyGems/RVM](#avoiding-conflicts-with-rubygemsrvm)
-    * [Initial setup](#initial-setup)
-    * [Beginning with the repo slimmer](#beginning-with-the-repo-slimmer)
-  * [Usage](#usage)
-    * [(Bolt) Provisioning the Pulp container](#bolt-provisioning-the-pulp-container)
-    * [(Script) `slim-pulp-repo-copy.rb` - Use Pulp to create slim repo mirrors](#script-slim-pulp-repo-copyrb---use-pulp-to-create-slim-repo-mirrors)
-    * [(Script) `_*.reposync.sh`: Mirror all slim repos into a local directory](#script-_reposyncsh-mirror-all-slim-repos-into-a-local-directory)
-    * [(You) Taking the repos and building SIMP](#you-taking-the-repos-and-building-simp)
-    * [(Bolt) Destroying the Pulp container](#bolt-destroying-the-pulp-container)
-      * [Destroying container, but preserving volumes (persists Pulp data)](#destroying-container-but-preserving-volumes-persists-pulp-data)
-      * [Destroying both container + volumes w/data (wipes Pulp clean)](#destroying-both-container--volumes-wdata-wipes-pulp-clean)
+- [Proof-of-concept Pulp3 Bolt project + modular repo mirror-slimmer](#proof-of-concept-pulp3-bolt-project--modular-repo-mirror-slimmer)
+  - [Overview](#overview)
+    - [Setup](#setup)
+      - [Setup Requirements](#setup-requirements)
+        - [OS requirements](#os-requirements)
+        - [OS Storage requirements](#os-storage-requirements)
+        - [Runtime dependencies](#runtime-dependencies)
+        - [Avoiding conflicts with RubyGems/RVM](#avoiding-conflicts-with-rubygemsrvm)
+      - [Initial setup](#initial-setup)
+      - [Beginning with the repo slimmer](#beginning-with-the-repo-slimmer)
+    - [Usage](#usage)
+      - [(Bolt) Provisioning the Pulp container](#bolt-provisioning-the-pulp-container)
+      - [(Script) `slim-pulp-repo-copy.rb` - Use Pulp to create slim repo mirrors](#script-slim-pulp-repo-copyrb---use-pulp-to-create-slim-repo-mirrors)
+      - [(Script) `_*.reposync.sh`: Mirror all slim repos into a local directory](#script-_reposyncsh-mirror-all-slim-repos-into-a-local-directory)
+      - [(You) Taking the repos and building SIMP](#you-taking-the-repos-and-building-simp)
+      - [(Bolt) Destroying the Pulp container](#bolt-destroying-the-pulp-container)
+        - [Destroying container, but preserving volumes (persists Pulp data)](#destroying-container-but-preserving-volumes-persists-pulp-data)
+        - [Destroying both container + volumes w/data (wipes Pulp clean)](#destroying-both-container--volumes-wdata-wipes-pulp-clean)
 
 <!-- vim-markdown-toc -->
 
@@ -83,7 +84,7 @@ The following components are needed to use all the features of this project.
     ```
 
 * You may also need to install `gcc` in order for Bolt to compile native ruby
-  gems during `/opt/puppetlabs/bolt/bin/gem install --user-install -g gem.deps.rb`:
+  gems during `/opt/puppetlabs/bolt/bin/bundle install`:
 
   * `gcc`
 
@@ -111,7 +112,7 @@ These dependencies can be installed by Bolt (see the [Initial
 setup](#initial-setup) section)
 
   * Puppet modules (defined in bolt project's `bolt-project.yaml`)
-  * Ruby Gems (defined in `gem.deps.rb`)
+  * RubyGems (defined in `Gemfile`)
 
 ##### Avoiding conflicts with RubyGems/RVM
 
@@ -141,8 +142,8 @@ with this project.
    command -v rvm && rvm use system
 
    # Install dependencies
-   /opt/puppetlabs/bolt/bin/bolt module install --force        # install Puppet modules
-   /opt/puppetlabs/bolt/bin/gem install --user -g gem.deps.rb  # install RubyGems
+   /opt/puppetlabs/bolt/bin/bolt module install --force  # install Puppet modules
+   /opt/puppetlabs/bolt/bin/bundle install               # install RubyGems
 
     # Verify `pulp3::` plans are visible
    bolt plan show
@@ -178,10 +179,10 @@ Mirror, filter, and resolve upstream repos into new "slim" repos for a distro:
 
 ```sh
 # See options for the ruby script
-./slim-pulp-repo-copy.rb --help
+ /opt/puppetlabs/bolt/bin/bundle exec ./slim-pulp-repo-copy.rb --help
 
 # Use Pulp to create slim versions of upstream repos
-./slim-pulp-repo-copy.rb --repos-rpms-file build/6.6.0/CentOS/8/x86_64/repo_packages.yaml
+/opt/puppetlabs/bolt/bin/bundle exec ./slim-pulp-repo-copy.rb --repos-rpms-file build/6.6.0/CentOS/8/x86_64/repo_packages.yaml
 ```
 
 After the script completes, run the following to check if there were problems

--- a/README.md
+++ b/README.md
@@ -2,24 +2,23 @@
 
 <!-- vim-markdown-toc GFM -->
 
-- [Proof-of-concept Pulp3 Bolt project + modular repo mirror-slimmer](#proof-of-concept-pulp3-bolt-project--modular-repo-mirror-slimmer)
-  - [Overview](#overview)
-    - [Setup](#setup)
-      - [Setup Requirements](#setup-requirements)
-        - [OS requirements](#os-requirements)
-        - [OS Storage requirements](#os-storage-requirements)
-        - [Runtime dependencies](#runtime-dependencies)
-        - [Avoiding conflicts with RubyGems/RVM](#avoiding-conflicts-with-rubygemsrvm)
-      - [Initial setup](#initial-setup)
-      - [Beginning with the repo slimmer](#beginning-with-the-repo-slimmer)
-    - [Usage](#usage)
-      - [(Bolt) Provisioning the Pulp container](#bolt-provisioning-the-pulp-container)
-      - [(Script) `slim-pulp-repo-copy.rb` - Use Pulp to create slim repo mirrors](#script-slim-pulp-repo-copyrb---use-pulp-to-create-slim-repo-mirrors)
-      - [(Script) `_*.reposync.sh`: Mirror all slim repos into a local directory](#script-_reposyncsh-mirror-all-slim-repos-into-a-local-directory)
-      - [(You) Taking the repos and building SIMP](#you-taking-the-repos-and-building-simp)
-      - [(Bolt) Destroying the Pulp container](#bolt-destroying-the-pulp-container)
-        - [Destroying container, but preserving volumes (persists Pulp data)](#destroying-container-but-preserving-volumes-persists-pulp-data)
-        - [Destroying both container + volumes w/data (wipes Pulp clean)](#destroying-both-container--volumes-wdata-wipes-pulp-clean)
+* [Overview](#overview)
+  * [Setup](#setup)
+    * [Setup Requirements](#setup-requirements)
+      * [OS requirements](#os-requirements)
+      * [OS Storage requirements](#os-storage-requirements)
+      * [Runtime dependencies](#runtime-dependencies)
+      * [Avoiding conflicts with RubyGems/RVM](#avoiding-conflicts-with-rubygemsrvm)
+    * [Initial setup](#initial-setup)
+    * [Beginning with the repo slimmer](#beginning-with-the-repo-slimmer)
+  * [Usage](#usage)
+    * [(Bolt) Provisioning the Pulp container](#bolt-provisioning-the-pulp-container)
+    * [(Script) `slim-pulp-repo-copy.rb` - Use Pulp to create slim repo mirrors](#script-slim-pulp-repo-copyrb---use-pulp-to-create-slim-repo-mirrors)
+    * [(Script) `_*.reposync.sh`: Mirror all slim repos into a local directory](#script-_reposyncsh-mirror-all-slim-repos-into-a-local-directory)
+    * [(You) Taking the repos and building SIMP](#you-taking-the-repos-and-building-simp)
+    * [(Bolt) Destroying the Pulp container](#bolt-destroying-the-pulp-container)
+      * [Destroying container, but preserving volumes (persists Pulp data)](#destroying-container-but-preserving-volumes-persists-pulp-data)
+      * [Destroying both container + volumes w/data (wipes Pulp clean)](#destroying-both-container--volumes-wdata-wipes-pulp-clean)
 
 <!-- vim-markdown-toc -->
 
@@ -179,10 +178,12 @@ Mirror, filter, and resolve upstream repos into new "slim" repos for a distro:
 
 ```sh
 # See options for the ruby script
- /opt/puppetlabs/bolt/bin/bundle exec ./slim-pulp-repo-copy.rb --help
+ /opt/puppetlabs/bolt/bin/bundle exec /opt/puppetlabs/bolt/bin/ruby ./slim-pulp-repo-copy.rb --help
 
 # Use Pulp to create slim versions of upstream repos
-/opt/puppetlabs/bolt/bin/bundle exec ./slim-pulp-repo-copy.rb --repos-rpms-file build/6.6.0/CentOS/8/x86_64/repo_packages.yaml
+/opt/puppetlabs/bolt/bin/bundle exec \
+  /opt/puppetlabs/bolt/bin/ruby \
+  ./slim-pulp-repo-copy.rb --repos-rpms-file build/6.6.0/CentOS/8/x86_64/repo_packages.yaml
 ```
 
 After the script completes, run the following to check if there were problems

--- a/slim-pulp-repo-copy.rb
+++ b/slim-pulp-repo-copy.rb
@@ -1043,7 +1043,7 @@ require 'pry'; binding.pry unless rpm_rpm_repository_version_href
       echo "Adding '$repo' to .repo file..."
       cat << REPO >> "$YUMREPO_FILE"
 
-      [${repo}]
+      [${repo}--simp]
       name=${repo}
       enabled=1
       baseurl=${REPOS_BASEURL:-$PATH_TO_LOCAL_MIRROR}/${repo}


### PR DESCRIPTION
DNF gets cranky and yells if two repos have the same title, even if one of them is disabled.