### PR TITLE
Builds RHEL8.7

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,10 +3,12 @@ pulp3::server_url: http://localhost
 pulp3::server_port: 8080
 
 pulp3::in_one_container::container_name: pulp
-pulp3::in_one_container::container_image: docker.io/pulp/pulp:3.19
+pulp3::in_one_container::container_image: docker.io/pulp/pulp:3.22
 pulp3::in_one_container::container_port: "%{alias('pulp3::server_port')}"
 
-pulp3::in_one_container::django_log: '/var/run/django-info.log'
+pulp3::in_one_container::startup_sleep_time: 60
+pulp3::in_one_container::django_log: '/tmp/django-info.log'
+pulp3::in_one_container::log_level: 'DEBUG'
 
 pulp3::in_one_container::destroy::force: true
 pulp3::in_one_container::destroy::volumes: true

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,12 +3,12 @@ pulp3::server_url: http://localhost
 pulp3::server_port: 8080
 
 pulp3::in_one_container::container_name: pulp
-pulp3::in_one_container::container_image: docker.io/pulp/pulp:3.22
+pulp3::in_one_container::container_image: docker.io/pulp/pulp:3.23
 pulp3::in_one_container::container_port: "%{alias('pulp3::server_port')}"
 
-pulp3::in_one_container::startup_sleep_time: 60
+pulp3::in_one_container::startup_sleep_time: 10
 pulp3::in_one_container::django_log: '/tmp/django-info.log'
-pulp3::in_one_container::log_level: 'DEBUG'
+pulp3::in_one_container::log_level: INFO
 
 pulp3::in_one_container::destroy::force: true
 pulp3::in_one_container::destroy::volumes: true

--- a/plans/in_one_container.pp
+++ b/plans/in_one_container.pp
@@ -87,4 +87,10 @@ plan pulp3::in_one_container (
     'targets'        => $host,
     'container_name' => $container_name,
   )
+
+  # TODO: optional automated post-install tasks
+  # - Creating/Uploading /allowed_imports/* content (RHEL ISOs, rpms)
+  # - Updating the pulp container
+  #
+  # Automating the build should be another plan at the same level as this logic (which should probably be refactored into a sub-plan
 }

--- a/plans/in_one_container.pp
+++ b/plans/in_one_container.pp
@@ -12,11 +12,11 @@ plan pulp3::in_one_container (
   String[1]                      $container_name     = lookup('pulp3::in_one_container::container_name')|$k|{'pulp'},
   String[1]                      $container_image    = lookup('pulp3::in_one_container::container_image')|$k|{'pulp/pulp'},
   Stdlib::Port                   $container_port     = lookup('pulp3::in_one_container::container_port')|$k|{8080},
-  Integer[0]                     $startup_sleep_time = 10,
+  Integer[0]                     $startup_sleep_time = lookup('pulp3::in_one_container::startup_sleep_time')|$k|{60},
   Boolean                        $skip_filesystem    = false,
   Optional[Sensitive[String[1]]] $admin_password     = Sensitive.new(system::env('PULP3_ADMIN_PASSWORD').lest||{'admin'}),
   Optional[Enum[podman,docker]]  $runtime            = undef,
-  String[1]                      $log_level          = 'INFO',
+  String[1]                      $log_level          = lookup('pulp3::in_one_container::log_level')|$k|{'INFO'},
   # FIXME not set up yet:
   Array[Stdlib::AbsolutePath] $import_paths          = lookup('pulp3::in_one_container::import_paths')|$k|{
     [ "${container_root}/run/ISOs/unpacked" ]
@@ -80,8 +80,8 @@ plan pulp3::in_one_container (
 
   $start_result = run_command($start_cmd, $host)
 
-  ctrl::sleep($startup_sleep_time)
   out::message("Waiting ${startup_sleep_time} seconds for pulp to start up...")
+  ctrl::sleep($startup_sleep_time)
   $admin_pw_result = run_plan(
     'pulp3::in_one_container::reset_admin_password',
     'targets'        => $host,

--- a/plans/in_one_container/create_settings.pp
+++ b/plans/in_one_container/create_settings.pp
@@ -9,7 +9,7 @@ plan pulp3::in_one_container::create_settings (
   String[1] $container_name,
   Stdlib::Port $container_port,
   Stdlib::HTTPUrl $host_baseurl = 'http://127.0.0.1', # $host.facts['fqdn']
-  Stdlib::AbsolutePath $django_log = lookup('pulp3::in_one_container::django_log')|$k|{'/var/run/django-info.log'},
+  Stdlib::AbsolutePath $django_log = lookup('pulp3::in_one_container::django_log')|$k|{'/tmp/django-info.log'},
   String[1] $log_level = 'INFO',
 ) {
 
@@ -33,20 +33,15 @@ plan pulp3::in_one_container::create_settings (
         },
         'handlers': {
             'console': {
+                'level': '${log_level}',
                 'class': 'logging.StreamHandler',
                 'formatter': 'console'
             },
-            'file': {
-                'level': '${log_level}',
-                'class': 'logging.FileHandler',
-                'formatter': 'file',
-                'filename': '${django_log}'
-            }
         },
         'loggers': {
             '': {
                 'level': '${log_level}',
-                'handlers': ['console', 'file']
+                'handlers': ['console']
             }
         }
     }

--- a/plans/in_one_container/reset_admin_password.pp
+++ b/plans/in_one_container/reset_admin_password.pp
@@ -4,7 +4,7 @@ plan pulp3::in_one_container::reset_admin_password (
   TargetSpec                     $targets        = 'localhost',
   String[1]                      $container_name = lookup('pulp3::in_one_container::container_name')|$k|{'pulp'},
   Integer                        $max_retries    = 10,
-  Integer                        $sleep_seconds  = 2,
+  Integer                        $sleep_seconds  = 5,
   Optional[Sensitive[String[1]]] $admin_password = Sensitive.new(system::env('PULP3_ADMIN_PASSWORD').lest||{'admin'}),
   Optional[Enum[podman,docker]]  $runtime        = undef,
 
@@ -32,7 +32,7 @@ plan pulp3::in_one_container::reset_admin_password (
     }
 
     if $x == $max_retries{
-      return $reset_result
+      return $cmd_result
     }
   }
 }

--- a/tasks/post_bolt_rhel87_prep.bash
+++ b/tasks/post_bolt_rhel87_prep.bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# TODO poll pulp status API in plan, then run a script like this (or via structured hiera)
+podman exec -it pulp mkdir -p /allowed_imports/RHEL-8-7-0-BaseOS-x86_64/{BaseOS,AppStream}/
+podman exec -it pulp mkdir -p /allowed_imports/codeready-builder-for-rhel-8-x86_64-rpms/
+
+podman cp  /run/media/$USER/RHEL-8-7-0-BaseOS-x86_64/BaseOS/ pulp:/allowed_imports/RHEL-8-7-0-BaseOS-x86_64/
+podman cp  /run/media/$USER/RHEL-8-7-0-BaseOS-x86_64/AppStream/ pulp:/allowed_imports/RHEL-8-7-0-BaseOS-x86_64/
+podman cp  codeready-builder-for-rhel-8-x86_64-rpms pulp:/allowed_imports/
+
+podman exec -it pulp pip install pulp-rpm==3.19.4
+
+podman container stop pulp
+podman container start pulp


### PR DESCRIPTION
The patch adds adjustments that were made to accommodate RHEL87.  Among other things, it: 

* Updates the pulp-in-one container to 3.23.0
  * NOTE: This required removing django's log file! :warning:
     * No permissions since PIO 3.22!
     * Even `/tmp` denies access under some conditions
   * Several new plan parameters are exposed in the plan Hiera
* Adds a task with post bolt plan updates used to build RHEL8.7 
  * Bash script
  * Set up `/allowed_imports` in pulp container
  * Copy in ISO and extra rpm repo
  * Upgrade pulp_rpm to 3.19.4 (released this afternoon)

:warning: The task assumes a mounted  ISO at a specific path; it's been added as a record of what was used.  Copy and edit it to suit your local situation!

I was run was run directly during test, but tested later by running `bolt task run pulp3::post_bolt_rhel87_prep -t localhost`