### PR TITLE
Fixed runtime path resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@
 /settings/
 /pulp_storage/
 /.plan_cache.json
+/.task_cache.json
+bolt_pulp3_config.yaml
+Puppetfile

--- a/plans/in_one_container.pp
+++ b/plans/in_one_container.pp
@@ -9,40 +9,41 @@ plan pulp3::in_one_container (
   TargetSpec                     $targets            = 'localhost',
   String[1]                      $user               = system::env('USER'),
   Stdlib::AbsolutePath           $container_root     = system::env('PWD'),
-  String[1]                      $container_name     = lookup('pulp3::in_one_container::container_name')|$k|{'pulp'},
-  String[1]                      $container_image    = lookup('pulp3::in_one_container::container_image')|$k|{'pulp/pulp'},
-  Stdlib::Port                   $container_port     = lookup('pulp3::in_one_container::container_port')|$k|{8080},
-  Integer[0]                     $startup_sleep_time = lookup('pulp3::in_one_container::startup_sleep_time')|$k|{60},
+  String[1]                      $container_name     = lookup('pulp3::in_one_container::container_name')|$k| { 'pulp' },
+  String[1]                      $container_image    = lookup('pulp3::in_one_container::container_image')|$k| { 'pulp/pulp' },
+  Stdlib::Port                   $container_port     = lookup('pulp3::in_one_container::container_port')|$k| { 8080 },
+  Integer[0]                     $startup_sleep_time = lookup('pulp3::in_one_container::startup_sleep_time')|$k| { 60 },
   Boolean                        $skip_filesystem    = false,
-  Optional[Sensitive[String[1]]] $admin_password     = Sensitive.new(system::env('PULP3_ADMIN_PASSWORD').lest||{'admin'}),
+  Optional[Sensitive[String[1]]] $admin_password     = Sensitive.new(system::env('PULP3_ADMIN_PASSWORD').lest|| { 'admin' }),
   Optional[Enum[podman,docker]]  $runtime            = undef,
-  String[1]                      $log_level          = lookup('pulp3::in_one_container::log_level')|$k|{'INFO'},
+  String[1]                      $log_level          = lookup('pulp3::in_one_container::log_level')|$k| { 'INFO' },
   # FIXME not set up yet:
-  Array[Stdlib::AbsolutePath] $import_paths          = lookup('pulp3::in_one_container::import_paths')|$k|{
-    [ "${container_root}/run/ISOs/unpacked" ]
+  Array[Stdlib::AbsolutePath] $import_paths          = lookup('pulp3::in_one_container::import_paths')|$k| {
+    ["${container_root}/run/ISOs/unpacked"]
   },
 ) {
   $host = run_plan('pulp3::in_one_container::get_host', 'targets' => $targets, 'runtime' => $runtime)
-  $runtime_exe = $host.facts['pioc_runtime_exe']
+  $_runtime = $host.facts['pioc_runtime']
+  $_runtime_exe = $host.facts['available_runtimes'][$_runtime]
 
   if run_plan( 'pulp3::in_one_container::match_container', {
-    'host'  => $host,
-    'name'  => $container_name,
-    'image' => $container_image,
-  }){
+      'host'  => $host,
+      'name'  => $container_name,
+      'image' => $container_image,
+  }) {
     out::message( "Container '${container_name}' already running!" )
     return undef
   }
 
   if run_plan( 'pulp3::in_one_container::match_container', {
-    'host'  => $host,
-    'name'  => $container_name,
-    'image' => $container_image,
-    'port'  => $container_port,
-    'all'   => true,
-  }){
+      'host'  => $host,
+      'name'  => $container_name,
+      'image' => $container_image,
+      'port'  => $container_port,
+      'all'   => true,
+  }) {
     out::message( "Restarting stopped container '${container_name}'..." )
-    return run_command( "${runtime_exe} container start ${container_name}", $host )
+    return run_command( "${_runtime_exe} container start ${container_name}", $host )
   }
 
   out::message( "Starting new container '${container_name}' from image '${container_image}'..." )
@@ -50,25 +51,25 @@ plan pulp3::in_one_container (
   $apply_result = run_plan(
     'pulp3::in_one_container::volumes::create', {
       'host'           => $host,
-      'runtime_exe'    => $runtime_exe,
+      'runtime_exe'    => $_runtime_exe,
       'container_name' => $container_name,
   })
 
   $settings_result = run_plan(
     'pulp3::in_one_container::create_settings', {
       'host'           => $host,
-      'runtime_exe'    => $runtime_exe,
+      'runtime_exe'    => $_runtime_exe,
       'container_name' => $container_name,
       'container_port' => $container_port,
       'host_baseurl'   => 'http://127.0.0.1',
       'log_level'      => $log_level,
   })
   $start_cmd = @("START_CMD"/n)
-    ${runtime_exe} run --detach \
+    ${_runtime_exe} run --detach \
       --name "${container_name}" \
       --publish "${container_port}:80" \
+      --platform linux/amd64 \
       --publish-all \
-      --log-driver journald \
       --device /dev/fuse \
       --volume "${container_name}-settings:/etc/pulp" \
       --volume "${container_name}-storage:/var/lib/pulp" \
@@ -86,6 +87,8 @@ plan pulp3::in_one_container (
     'pulp3::in_one_container::reset_admin_password',
     'targets'        => $host,
     'container_name' => $container_name,
+    'runtime'        => $runtime,
+    'runtime_exe'    => $_runtime_exe,
   )
 
   # TODO: optional automated post-install tasks

--- a/plans/in_one_container/create_settings.pp
+++ b/plans/in_one_container/create_settings.pp
@@ -9,10 +9,9 @@ plan pulp3::in_one_container::create_settings (
   String[1] $container_name,
   Stdlib::Port $container_port,
   Stdlib::HTTPUrl $host_baseurl = 'http://127.0.0.1', # $host.facts['fqdn']
-  Stdlib::AbsolutePath $django_log = lookup('pulp3::in_one_container::django_log')|$k|{'/tmp/django-info.log'},
+  Stdlib::AbsolutePath $django_log = lookup('pulp3::in_one_container::django_log')|$k| { '/tmp/django-info.log' },
   String[1] $log_level = 'INFO',
 ) {
-
   $pulp_settings = @("SETTINGS"/n)
     CONTENT_ORIGIN='${host_baseurl}:${container_port}'
     ANSIBLE_API_HOSTNAME='${host_baseurl}:${container_port}'
@@ -48,8 +47,8 @@ plan pulp3::in_one_container::create_settings (
     | SETTINGS
 
   catch_errors() || {
-    $tmp_container_out         = run_command("${runtime_exe} run -id --name ${container_name}_tmp --volume ${container_name}-settings:/pulp centos:8", $host)
-    $create_settings_py_out    = run_command("(${runtime_exe} exec -i ${container_name}_tmp sh -c 'cat > /pulp/settings.py') << EOM\n${pulp_settings}\nEOM", $host)
+    $tmp_container_out         = run_command("${runtime_exe} run -id --name ${container_name}_tmp --volume ${container_name}-settings:/pulp centos:8", $host) # lint:ignore:140chars
+    $create_settings_py_out    = run_command("(${runtime_exe} exec -i ${container_name}_tmp sh -c 'cat > /pulp/settings.py') << EOM\n${pulp_settings}\nEOM", $host) # lint:ignore:140chars
     $destroy_tmp_container_out = run_command("${runtime_exe} rm -f ${container_name}_tmp", $host)
   }
 }

--- a/plans/in_one_container/get_host.pp
+++ b/plans/in_one_container/get_host.pp
@@ -1,21 +1,28 @@
 # @summary Ensures a TargetSpec is a run-ready PIOC host Target with new fact
-#   `pioc_runtime_exe` ('docker' or 'podman')
+#   `pioc_runtime` ('docker' or 'podman') and `available_runtimes` (Hash of all
+#   available container runtimes on the host, mapped to their executable paths)
 # @return Target  a single host Target, with facts
 # @api private
 #
 # @param targets  A single target to run on (the container host)
 plan pulp3::in_one_container::get_host (
-  TargetSpec           $targets         = 'localhost',
+  TargetSpec                    $targets = 'localhost',
   Optional[Enum[podman,docker]] $runtime = undef,
 ) {
   $host = get_target($targets)
   run_plan('facts', 'targets' => $host)
 
-  $available_runtime_exes = ['podman','docker'].map |$exe| {
-    if run_command(
-      "command -v \"${exe}\"", $host, { '_catch_errors' => true }
-    )[0].value['exit_code'] == 0 { $exe }
-  }.filter |$x| { $x }
+  $available_runtime_exes = ['podman','docker'].reduce({}) |Hash $memo, String $exe| {
+    $_runtime_check = run_command("command -v '${exe}'", $host,
+      '_catch_errors' => true,
+    )
+    if $_runtime_check[0].value['exit_code'] == 0 {
+      $new_memo = $memo + { $exe => strip($_runtime_check[0].value['stdout']) }
+    } else {
+      $new_memo = $memo
+    }
+    $new_memo
+  }
 
   # CentOS 7 (and EL7) must use docker instead of podman
   #
@@ -33,14 +40,16 @@ plan pulp3::in_one_container::get_host (
       default => 'podman',
     }
   }
-  unless $_runtime in $available_runtime_exes {
-    fail_plan( "FATAL: The container runtime executable '${_runtime}' is not available on '${host}'.  Make sure the correct container runtime is installed and configured." )
+  unless $_runtime in $available_runtime_exes.keys() {
+    fail_plan( "FATAL: The container runtime executable '${_runtime}' is not available on '${host}'.  Make sure the correct container runtime is installed and configured." ) # lint:ignore:140chars
   }
 
-  $host.add_facts({
-    'pioc_runtime_exe' => $_runtime,
-  })
+  $host.add_facts(
+    {
+      'pioc_runtime'       => $_runtime,
+      'available_runtimes' => $available_runtime_exes,
+    }
+  )
 
   return $host
 }
-

--- a/plans/in_one_container/get_log.pp
+++ b/plans/in_one_container/get_log.pp
@@ -5,30 +5,38 @@
 # @param container_image Target Docker/podman image
 # @param runtime Container runtime executable to use (`undef` = autodetect)
 plan pulp3::in_one_container::get_log (
-  TargetSpec                    $targets         = 'localhost',
-  String[1]                     $user            = system::env('USER'),
-  String[1]                     $container_name  = lookup('pulp3::in_one_container::container_name')|$k|{'pulp'},
-  String[1]                     $container_image = lookup('pulp3::in_one_container::container_image')|$k|{'pulp/pulp'},
-  Optional[Enum[podman,docker]] $runtime         = undef,
-  Integer                       $lines           = 5,
-  Stdlib::AbsolutePath          $src_path        = lookup('pulp3::in_one_container::django_log')|$k|{'/var/run/django-info.log'},
+  TargetSpec                        $targets         = 'localhost',
+  String[1]                         $user            = system::env('USER'),
+  String[1]                         $container_name  = lookup('pulp3::in_one_container::container_name')|$k| { 'pulp' },
+  String[1]                         $container_image = lookup('pulp3::in_one_container::container_image')|$k| { 'pulp/pulp' },
+  Optional[Enum['podman','docker']] $runtime         = $host.facts['pioc_runtime'],
+  Optional[String[1]]               $runtime_exe     = $host.facts['available_runtimes'][$runtime],
+  Integer                           $lines           = 5,
+  Stdlib::AbsolutePath              $src_path        = lookup('pulp3::in_one_container::django_log')|$k| { '/var/run/django-info.log' },
 ) {
-  $host = run_plan( 'pulp3::in_one_container::get_host', $targets )
+  if $runtime and $runtime_exe {
+    $host = get_target($targets)
+    $_runtime = $runtime
+    $_runtime_exe = $runtime_exe
+  } else {
+    $host = run_plan('pulp3::in_one_container::get_host', 'targets' => $targets, 'runtime' => $runtime)
+    $_runtime = $host.facts['pioc_runtime']
+    $_runtime_exe = $host.facts['available_runtimes'][$_runtime]
+  }
   unless run_plan( 'pulp3::in_one_container::match_container', {
-    'host'        => $host,
-    'name'        => $container_name,
-    'image'       => $container_image,
-    'all'         => true,
-    'runtime_exe' => $host.facts['pioc_runtime_exe']
-  }){
+      'host'        => $host,
+      'name'        => $container_name,
+      'image'       => $container_image,
+      'all'         => true,
+      'runtime_exe' => $_runtime_exe
+  }) {
     fail_plan( "Cannot find container '${container_name}'" )
   }
 
   $container = Target.new({
-    'name' => $container_name,
-    'uri'  => "${host.facts['pioc_runtime_exe']}://${container_name}",
+      'name' => $container_name,
+      'uri'  => "${_runtime}://${container_name}",
   })
-
 
   # download
   # --------------------------------------------------------------------------
@@ -39,16 +47,16 @@ plan pulp3::in_one_container::get_log (
   # sanitize
   # --------------------------------------------------------------------------
   $log_txt = file::read($dl_path)
-  $clean_log_lines = $log_txt.split("\n").filter |$x|{
+  $clean_log_lines = $log_txt.split("\n").filter |$x| {
     $x !~ /Header `Correlation-ID` was not found in the incoming request/
   }
   $clean_dl_path = "${dl_path.dirname}/${src_path.basename}.sanitized"
   $w = file::write($clean_dl_path, $clean_log_lines.join("\n"))
 
   out::message([
-    "\nLast ${lines} (sanitized) log lines:\n------------------------------------",
-    $clean_log_lines[-1*$lines,-1].join("\n"),
-    '',
+      "\nLast ${lines} (sanitized) log lines:\n------------------------------------",
+      $clean_log_lines[-1*$lines,-1].join("\n"),
+      '',
   ].join("\n"))
   out::message("\nLog downloaded to:\n\t${dl_path}\n")
   out::message("\nWrote sanitized log to:\n\t${clean_dl_path}\n\n")

--- a/plans/in_one_container/match_container.pp
+++ b/plans/in_one_container/match_container.pp
@@ -7,12 +7,13 @@
 #
 # Details at https://pulpproject.org/pulp-in-one-container/
 plan pulp3::in_one_container::match_container(
-  TargetSpec             $host,
-  Boolean                $all   = false,
-  String[1]              $name  = lookup('pulp3::in_one_container::container_name')|$k|{'pulp'},
-  String[1]              $image = lookup('pulp3::in_one_container::container_image')|$k|{'pulp/pulp'},
-  Optional[Stdlib::Port] $port  = undef,
-  Optional[String[1]]    $runtime_exe = $host.facts['pioc_runtime_exe']
+  TargetSpec                        $host,
+  Boolean                           $all         = false,
+  String[1]                         $name        = lookup('pulp3::in_one_container::container_name')|$k| { 'pulp' },
+  String[1]                         $image       = lookup('pulp3::in_one_container::container_image')|$k| { 'pulp/pulp' },
+  Optional[Stdlib::Port]            $port        = undef,
+  Optional[Enum['podman','docker']] $runtime     = $host.facts['pioc_runtime'],
+  Optional[String[1]]               $runtime_exe = $host.facts['available_runtimes'][$runtime],
 ) {
   $extra_args  = $all ? { true => '-a', default => '' }
 

--- a/plans/in_one_container/reset_admin_password.pp
+++ b/plans/in_one_container/reset_admin_password.pp
@@ -2,25 +2,33 @@
 # @param targets A single target to run on (the container host)
 plan pulp3::in_one_container::reset_admin_password (
   TargetSpec                     $targets        = 'localhost',
-  String[1]                      $container_name = lookup('pulp3::in_one_container::container_name')|$k|{'pulp'},
+  String[1]                      $container_name = lookup('pulp3::in_one_container::container_name')|$k| { 'pulp' },
   Integer                        $max_retries    = 10,
   Integer                        $sleep_seconds  = 5,
-  Optional[Sensitive[String[1]]] $admin_password = Sensitive.new(system::env('PULP3_ADMIN_PASSWORD').lest||{'admin'}),
+  Optional[Sensitive[String[1]]] $admin_password = Sensitive.new(system::env('PULP3_ADMIN_PASSWORD').lest|| { 'admin' }),
   Optional[Enum[podman,docker]]  $runtime        = undef,
+  Optional[String]               $runtime_exe    = undef,
 
 ) {
-  $host = run_plan('pulp3::in_one_container::get_host', 'targets' => $targets, 'runtime' => $runtime)
-  $runtime_exe = $host.facts['pioc_runtime_exe']
+  if $runtime and $runtime_exe {
+    $host = get_target($targets)
+    $_runtime = $runtime
+    $_runtime_exe = $runtime_exe
+  } else {
+    $host = run_plan('pulp3::in_one_container::get_host', 'targets' => $targets, 'runtime' => $runtime)
+    $_runtime = $host.facts['pioc_runtime']
+    $_runtime_exe = $host.facts['available_runtimes'][$_runtime]
+  }
 
-  $admin_reset_cmd = "/bin/sh -c '${runtime_exe} exec ${container_name} bash -c \"pulpcore-manager reset-admin-password -p \$PULP3_ADMIN_PASSWORD\"'"
+  $admin_reset_cmd = "/bin/sh -c '${_runtime_exe} exec ${container_name} bash -c \"pulpcore-manager reset-admin-password -p \$PULP3_ADMIN_PASSWORD\"'" # lint:ignore:140chars
   log::debug( "Running:\n\n\t${admin_reset_cmd}\n" )
 
   range(1, $max_retries).each |Integer $x| {
     log::info("Attempt ${x} of ${max_retries} to set the admin password")
 
     $cmd_result = run_command($admin_reset_cmd, $host, {
-      '_env_vars'     => { 'PULP3_ADMIN_PASSWORD' => $admin_password.unwrap },
-      '_catch_errors' => true
+        '_env_vars'     => { 'PULP3_ADMIN_PASSWORD' => $admin_password.unwrap },
+        '_catch_errors' => true
     })
 
     if $cmd_result.ok {
@@ -31,7 +39,7 @@ plan pulp3::in_one_container::reset_admin_password (
       run_command("sleep ${sleep_seconds}", $host)
     }
 
-    if $x == $max_retries{
+    if $x == $max_retries {
       return $cmd_result
     }
   }

--- a/plans/in_one_container/volumes/create.pp
+++ b/plans/in_one_container/volumes/create.pp
@@ -15,7 +15,7 @@ plan pulp3::in_one_container::volumes::create (
     'pgsql',
     'run',
     'settings',
-    'storage'
+    'storage',
   ],
   Boolean $noop = false,
 ) {
@@ -24,7 +24,7 @@ plan pulp3::in_one_container::volumes::create (
     '_description' => 'Ensure volumes exist for pulp container',
     '_noop' => $noop,
     '_catch_errors' => false,
-  ){
+  ) {
     $volume_names.each |String $volume_name| {
       $_vname = "${container_name}-${volume_name}"
 
@@ -33,12 +33,8 @@ plan pulp3::in_one_container::volumes::create (
         unless  => "${runtime_exe} volume inspect ${_vname}",
         path    => [
           '/bin',
-          '/usr/bin'
-        ]
+          '/usr/bin',
+        ],
       }
     }
-  }
-
-
-
-}
+} }

--- a/plans/in_one_container/volumes/destroy.pp
+++ b/plans/in_one_container/volumes/destroy.pp
@@ -15,7 +15,7 @@ plan pulp3::in_one_container::volumes::destroy (
     'pgsql',
     'run',
     'settings',
-    'storage'
+    'storage',
   ],
   Boolean $noop = false,
 ) {
@@ -24,7 +24,7 @@ plan pulp3::in_one_container::volumes::destroy (
     '_description' => 'Remove container volumes',
     '_noop' => $noop,
     '_catch_errors' => false,
-  ){
+  ) {
     $volume_names.each |String $volume_name| {
       $_vname = "${container_name}-${volume_name}"
 
@@ -33,8 +33,8 @@ plan pulp3::in_one_container::volumes::destroy (
         onlyif  => "${runtime_exe} volume inspect ${_vname}",
         path    => [
           '/bin',
-          '/usr/bin'
-        ]
+          '/usr/bin',
+        ],
       }
     }
   }


### PR DESCRIPTION
When the runtime exists in a place that is not in the predicted path configured in some plans like `pulp3::in_one_container::volumes::create`, the plan will fail. My change will capture the output collected from the `command -v` executed by `pulp3::in_one_container::get_host` to get the path to all container runtimes so that commands can be executed with the fully qualified path.

Also, while I was in there, I went ahead and ran puppet lint on everything. If y'all want, I can spin that off to another PR.