### PR TITLE
Match Pulp client gem deps with container

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"
-gem 'pulpcore_client'
-gem 'pulp_rpm_client'
+gem 'pulpcore_client', '~> 3.22.2'
+gem 'pulp_rpm_client', '~> 3.19.0'
 gem 'bindata'
 gem 'down'
 gem 'logging'

--- a/plans/in_one_container/destroy.pp
+++ b/plans/in_one_container/destroy.pp
@@ -18,7 +18,7 @@ plan pulp3::in_one_container::destroy (
 ) {
   $host = run_plan('pulp3::in_one_container::get_host',$targets)
   $_runtime = $host.facts['pioc_runtime']
-  $_runtime_exe = $host.facts['available_runtimes'][$runtime]
+  $_runtime_exe = $host.facts['available_runtimes'][$_runtime]
 
   if run_plan( 'pulp3::in_one_container::match_container', {
       'host'        => $host,

--- a/tasks/post_bolt_rhel87_prep.bash
+++ b/tasks/post_bolt_rhel87_prep.bash
@@ -1,14 +1,34 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -x
+set -euo pipefail
+
+for v in ${!PT_*}; do
+  echo "=============== ${v}"
+  declare "${v#*PT_}"="${!v}"
+done
+
+
+env > /home/chris/src/simp-core-pretty/bolt-pulp3/BOLT.ENV.VARS.txt
+
+PULP_CONTAINER_NAME="${PT_pulp_container_name:-pulp}"
+MOUNTED_ISO_ROOT_DIR="${PT_rhel_iso_root_dir:-"/run/media/$USER/RHEL-8-7-0-BaseOS-x86_64"}"
+RUNTIME_EXE=podman
+
+echo "PULP_CONTAINER_NAME: '${PULP_CONTAINER_NAME}'"
+echo "MOUNTED_ISO_ROOT_DIR: '${MOUNTED_ISO_ROOT_DIR}'"
+
+[[ -d "$MOUNTED_ISO_ROOT_DIR" ]] || { >&2 echo "ERROR: No ISO directory found at ${MOUNTED_ISO_ROOT_DIR}"; exit 99; }
 
 # TODO poll pulp status API in plan, then run a script like this (or via structured hiera)
-podman exec -it pulp mkdir -p /allowed_imports/RHEL-8-7-0-BaseOS-x86_64/{BaseOS,AppStream}/
-podman exec -it pulp mkdir -p /allowed_imports/codeready-builder-for-rhel-8-x86_64-rpms/
+"$RUNTIME_EXE" exec -it "$PULP_CONTAINER_NAME" mkdir -p /allowed_imports/RHEL-8-7-0-BaseOS-x86_64/{BaseOS,AppStream}/
+"$RUNTIME_EXE" exec -it "$PULP_CONTAINER_NAME" mkdir -p /allowed_imports/codeready-builder-for-rhel-8-x86_64-rpms/
 
-podman cp  /run/media/$USER/RHEL-8-7-0-BaseOS-x86_64/BaseOS/ pulp:/allowed_imports/RHEL-8-7-0-BaseOS-x86_64/
-podman cp  /run/media/$USER/RHEL-8-7-0-BaseOS-x86_64/AppStream/ pulp:/allowed_imports/RHEL-8-7-0-BaseOS-x86_64/
-podman cp  codeready-builder-for-rhel-8-x86_64-rpms pulp:/allowed_imports/
+"$RUNTIME_EXE" cp  "$MOUNTED_ISO_ROOT_DIR/BaseOS/" "$PULP_CONTAINER_NAME":/allowed_imports/RHEL-8-7-0-BaseOS-x86_64/
+"$RUNTIME_EXE" cp  "$MOUNTED_ISO_ROOT_DIR/AppStream/" "$PULP_CONTAINER_NAME":/allowed_imports/RHEL-8-7-0-BaseOS-x86_64/
+"$RUNTIME_EXE" cp  codeready-builder-for-rhel-8-x86_64-rpms "$PULP_CONTAINER_NAME":/allowed_imports/
 
-podman exec -it pulp pip install pulp-rpm==3.19.4
+"$RUNTIME_EXE" exec -it "$PULP_CONTAINER_NAME" pip install --upgrade-strategy only-if-needed 'pulp-rpm>=3.19.4'
 
-podman container stop pulp
-podman container start pulp
+"$RUNTIME_EXE" container stop "$PULP_CONTAINER_NAME"
+"$RUNTIME_EXE" container start "$PULP_CONTAINER_NAME"

--- a/tasks/post_bolt_rhel87_prep.bash
+++ b/tasks/post_bolt_rhel87_prep.bash
@@ -10,7 +10,7 @@ done
 
 PULP_CONTAINER_NAME="${PT_pulp_container_name:-pulp}"
 MOUNTED_ISO_ROOT_DIR="${PT_rhel_iso_root_dir:-"/run/media/$USER/RHEL-8-7-0-BaseOS-x86_64"}"
-RUNTIME_EXE=podman
+RUNTIME_EXE="${PT_runtime_exe:-podman}"
 
 echo "PULP_CONTAINER_NAME: '${PULP_CONTAINER_NAME}'"
 echo "MOUNTED_ISO_ROOT_DIR: '${MOUNTED_ISO_ROOT_DIR}'"

--- a/tasks/post_bolt_rhel87_prep.bash
+++ b/tasks/post_bolt_rhel87_prep.bash
@@ -8,9 +8,6 @@ for v in ${!PT_*}; do
   declare "${v#*PT_}"="${!v}"
 done
 
-
-env > /home/chris/src/simp-core-pretty/bolt-pulp3/BOLT.ENV.VARS.txt
-
 PULP_CONTAINER_NAME="${PT_pulp_container_name:-pulp}"
 MOUNTED_ISO_ROOT_DIR="${PT_rhel_iso_root_dir:-"/run/media/$USER/RHEL-8-7-0-BaseOS-x86_64"}"
 RUNTIME_EXE=podman

--- a/tasks/post_bolt_rhel87_prep.json
+++ b/tasks/post_bolt_rhel87_prep.json
@@ -7,6 +7,11 @@
       "default": "pulp",
       "type": "String[1]"
     },
+    "runtime_exe": {
+      "description": "Container executable (e.g., podman, docker)",
+      "default": "podman",
+      "type": "String[1]"
+    },    
     "rhel_iso_root_dir": {
       "description": "Absolute path to mounted or unpacked RHEL ISO directory",
       "type": "Optional[Stdlib::Absolutepath]"

--- a/tasks/post_bolt_rhel87_prep.json
+++ b/tasks/post_bolt_rhel87_prep.json
@@ -1,5 +1,5 @@
 {
-  "description": "Allows you to execute arbitrary SQL",
+  "description": "Preps a Pulp-in-one-container to slim-mirror RHEL8 packages from an unpacked/mounted ISO",
   "input_method": "environment",
   "parameters": {
     "pulp_container_name": {

--- a/tasks/post_bolt_rhel87_prep.json
+++ b/tasks/post_bolt_rhel87_prep.json
@@ -1,0 +1,15 @@
+{
+  "description": "Allows you to execute arbitrary SQL",
+  "input_method": "environment",
+  "parameters": {
+    "pulp_container_name": {
+      "description": "Name of Pulp container to update",
+      "default": "pulp",
+      "type": "String[1]"
+    },
+    "rhel_iso_root_dir": {
+      "description": "Absolute path to mounted or unpacked RHEL ISO directory",
+      "type": "Optional[Stdlib::Absolutepath]"
+    }
+  }
+}


### PR DESCRIPTION
This patch fixes a RubyGem mismatch between the Pulp container version and the Bundled RubyGems in fresh project instances.

It also fixes a bug recently introduced in
`plans::in_one_container::destroy` and adds parameters to customize the `post_bolt_rhel87_prep` task.